### PR TITLE
Create ja_jp.json for 26.1

### DIFF
--- a/src/main/resources/assets/luminax/lang/ja_jp.json
+++ b/src/main/resources/assets/luminax/lang/ja_jp.json
@@ -1,0 +1,21 @@
+{
+  "block.luminax.luminax_block": "Luminaxブロック",
+  "block.luminax.luminax_button": "Luminaxのボタン",
+  "block.luminax.luminax_pressure_plate": "Luminaxの感圧板",
+  "block.luminax.luminax_slab": "Luminaxのハーフブロック",
+  "block.luminax.luminax_stair": "Luminaxの階段",
+  "block.luminax.luminax_wall": "Luminaxの塀",
+  "creative_tab.luminax.default": "Luminax",
+  "item.luminax.luminax_wand": "Luminaxの杖",
+  "key.category.luminax.default": "Luminax",
+  "key.luminax.open_color_picker": "カラーピッカーを開く",
+  "key.luminax.toggle_glowing": "発光の切り替え",
+  "property.luminax.color": "色",
+  "property.luminax.color.tooltip": "ブロックの色を変更します",
+  "property.luminax.glowing": "発光",
+  "tooltip.luminax.glowing.off": "ブロックが光を発するようにします",
+  "tooltip.luminax.glowing.on": "ブロックが光を発するようにします",
+  "tooltip.luminax.lmb": "%sまたは%sで順方向に切り替え",
+  "tooltip.luminax.mmb": "%sでカラーピッカーを開く",
+  "tooltip.luminax.rmb": "%sまたは%sで逆方向に切り替え"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added Japanese language support with translated strings for blocks, creative tab, items, keys, and tooltips including color and glowing-related properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SathLabs/Luminax/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->